### PR TITLE
Enable Turbopack and publish the tested image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -93,14 +93,35 @@ jobs:
             *) echo "Unexpected image content type: $image_content_type"; exit 1 ;;
           esac
 
+      - name: Save tested image
+        if: github.ref == 'refs/heads/master'
+        run: |
+          set -o pipefail
+          docker save antonve-site:test | gzip -1 > antonve-site-test.tar.gz
+
+      - name: Upload tested image
+        if: github.ref == 'refs/heads/master'
+        uses: actions/upload-artifact@v7
+        with:
+          name: production-image
+          path: antonve-site-test.tar.gz
+          compression-level: 0
+          retention-days: 1
+          if-no-files-found: error
+
   publish:
     name: Publish Image
     needs: [build, container]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
     steps:
-      - name: Checkout
-        uses: actions/checkout@v7
+      - name: Download tested image
+        uses: actions/download-artifact@v8
+        with:
+          name: production-image
+
+      - name: Load tested image
+        run: gunzip --stdout antonve-site-test.tar.gz | docker load
 
       - name: Push images
         run: |
@@ -108,7 +129,7 @@ jobs:
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u tadoku --password-stdin
           # Push images
           IMAGE_NAME=ghcr.io/antonve/antonve.be/web
-          docker build -t $IMAGE_NAME:latest .
-          docker tag $IMAGE_NAME:latest $IMAGE_NAME:$GITHUB_SHA
+          docker tag antonve-site:test $IMAGE_NAME:latest
+          docker tag antonve-site:test $IMAGE_NAME:$GITHUB_SHA
           docker push $IMAGE_NAME:latest
           docker push $IMAGE_NAME:$GITHUB_SHA

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 # Builder image
 FROM docker.io/node:24.18.0-alpine AS build
 
-ARG PROJECT_NAME
-
 WORKDIR /app
 
 # Set up pnpm
@@ -14,12 +12,9 @@ RUN pnpm fetch
 COPY . .
 RUN pnpm install --frozen-lockfile --offline
 RUN pnpm run build
-RUN CI=true pnpm install --prod --frozen-lockfile --offline --shamefully-hoist
 
 # Runtime image
 FROM docker.io/node:24.18.0-alpine AS release
-
-ARG PROJECT_NAME
 
 ENV PORT=3000
 
@@ -28,13 +23,8 @@ RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 
 COPY --from=build --chown=nextjs:nodejs /app/.next/standalone ./
-COPY --from=build --chown=nextjs:nodejs /app/.next/static* ./.next/static
-COPY --from=build --chown=nextjs:nodejs /app/public* ./public
-
-# WORKAROUND FOR: https://github.com/vercel/next.js/discussions/39432
-RUN rm -rf ./node_modules
-COPY --from=build /app/node_modules ./node_modules
-# END WORKAROUND
+COPY --from=build --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=build --chown=nextjs:nodejs /app/public ./public
 
 USER nextjs
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   },
   "packageManager": "pnpm@10.30.3",
   "scripts": {
-    "dev": "next dev --webpack",
-    "build": "next build --webpack",
+    "dev": "next dev",
+    "build": "next build",
     "start": "next start",
     "lint": "eslint . --max-warnings=0",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## What changed

- enable Next.js 16.3's default Turbopack path by restoring `next dev` and `next build`
- remove unused Docker build arguments and the post-build production reinstall
- remove the legacy full-`node_modules` runtime replacement; the release image now copies only standalone traces, static output, and public assets
- transport the exact smoke-tested `antonve-site:test` image from the Container job to Publish on master through a one-day artifact
- load and tag that tested image as both `latest` and `$GITHUB_SHA` instead of rebuilding during publication

No Turbopack configuration or application code changed. Node 24.18.0 Alpine and non-root UID 1001 remain exact.

PR workflows still skip image transfer and publication. On master, Publish remains dependent on both Verify and Container; the image is saved only after Container's runtime smoke passes.

## Gate evidence

- `pnpm install --frozen-lockfile`: pass
- `pnpm run lint`: pass with zero warnings
- `pnpm run typecheck`: pass
- clean `pnpm run build`: pass with Next.js 16.3.0 Turbopack
- `pnpm audit --prod`: no known vulnerabilities
- exact `mcr.microsoft.com/playwright:v1.62.1-noble` browser suite: 8/8 pass in 10.0s
- console/page-error assertions show no hydration or runtime regressions
- no screenshot baselines changed
- workflow YAML lint: pass
- `git diff --check`: pass
- hosted workflow run `31210542719`: Verify passed in 1m23s; expanded Container passed in 34s; Publish correctly skipped on the PR

## Independent container gates

Two separate `docker build --no-cache` images passed the complete runtime gate:

- image A: 20.570s, 70,118,873 bytes
- image B: 20.401s, 70,118,877 bytes
- PR9 rollback image: 167,219,093 bytes
- image A delta from PR9: **-97,100,220 bytes**

Both images passed:

- runtime user `nextjs`, UID 1001, Node v24.18.0
- `/`: 200, 4,200 bytes
- `/projects`: 200, 5,487 bytes
- `/books`: 200, 25,781 bytes
- missing route: 404, 2,463 bytes
- favicon ICO/PNG and source logo/profile images: 200 with expected image content types
- optimized profile image: 200 `image/jpeg`, 6,481 bytes
- runtime logs: no warnings, errors, or failures

The runtime has a traced dependency tree only: 37,860,426 bytes and five top-level entries, with ESLint absent. Sharp 0.35.3's musl native binary and libvips are present in the trace, and the optimized-image request confirms they load successfully.

## Build metrics

| Metric | PR9 Webpack | PR10 Turbopack | Delta |
| --- | ---: | ---: | ---: |
| clean build wall time | 13.852s | 5.196s | -8.656s |
| standalone tree (`du`) | 51,006,753 B | 38,421,117 B | -12,585,636 B |
| static tree (`du`) | 763,658 B | 778,730 B | +15,072 B |
| emitted CSS | 13,943 B | 12,582 B | -1,361 B |
| emitted JS | 725,139 B | 753,860 B | +28,721 B |

PR10 emits 32 static files versus PR9's 16 because Turbopack chunks the output differently. Browser screenshots remain identical.
