### PR TITLE
Publish production image tag

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -129,7 +129,9 @@ jobs:
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u tadoku --password-stdin
           # Push images
           IMAGE_NAME=ghcr.io/antonve/antonve.be/web
+          docker tag antonve-site:test $IMAGE_NAME:prod
           docker tag antonve-site:test $IMAGE_NAME:latest
           docker tag antonve-site:test $IMAGE_NAME:$GITHUB_SHA
+          docker push $IMAGE_NAME:prod
           docker push $IMAGE_NAME:latest
           docker push $IMAGE_NAME:$GITHUB_SHA


### PR DESCRIPTION
## Summary
- publish the tested website image with the `prod` deployment tag
- keep the existing `latest` and commit SHA tags

This aligns website releases with the production-only Tadoku Image Updater webhook.